### PR TITLE
Removed getX() and getY() and changed Distance class to use getValue()

### DIFF
--- a/src/Distance.java
+++ b/src/Distance.java
@@ -22,8 +22,9 @@ public class Distance {
         for(Record i: cCentres)
         {
             //latitude and longitude for each centre
-            double lat2 = i.getY();
-            double lon2 = i.getX();
+            double lat2 = Double.parseDouble(i.getValue(4));
+            double lon2 = Double.parseDouble(i.getValue(3));
+            ;
             //distance
             double dist = calcDist(lat2, lon2, cCentres);
             if(dist<=5)

--- a/src/Record.java
+++ b/src/Record.java
@@ -51,14 +51,6 @@ public class Record implements Template
     {
         return recordMap.get(fieldIndex).value;
     }
-    public double getX()
-    {
-        return Double.parseDouble(recordMap.get(3).value);
-    }
-    public double getY()
-    {
-        return Double.parseDouble(recordMap.get(4).value);
-    }
 
     class Field
     {


### PR DESCRIPTION
To keep the Record class more general for any dataset, removed the getX() and getY() that was used in the Distance class. Made the Distance class use the general getValue() method instead.